### PR TITLE
HH-132016 build improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
                         <preparationGoals>clean install</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <useReleaseProfile>false</useReleaseProfile>
+                        <localCheckout>true</localCheckout>
+                        <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -153,6 +155,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>ru.hh.checkstyle</groupId>
                 <artifactId>hh-maven-checkstyle-plugin</artifactId>
                 <configuration>
@@ -181,7 +194,6 @@
                 <executions>
                     <execution>
                         <id>enforce-no-snapshots</id>
-                        <phase>deploy</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-132016

Сделал, чтобы проверка на снепшотные зависимости в релизе выполнялась на более ранней стадии. Ещё добавил по умолчанию всем генерацию sources jar и потюнил maven-release-plugin.
