### PR TITLE
HH-153587 fix properties warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <propertiesEncoding>UTF-8</propertiesEncoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-153587

Фикс предупреждения мавена:

> [INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
