### PR TITLE
HH-201437 : Move smallrye open api plugin to compile phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
                     <version>${smallrye-open-api-maven-plugin.version}</version>
                     <executions>
                         <execution>
+                            <phase>compile</phase>
                             <goals>
                                 <goal>generate-schema</goal>
                             </goals>


### PR DESCRIPTION
version changes : Minor
description :

- smallrye-open-api-maven-plugin moved to compile phase